### PR TITLE
Fix to allow installation on Ubuntu with Puppet 4

### DIFF
--- a/manifests/repo/debian.pp
+++ b/manifests/repo/debian.pp
@@ -22,7 +22,7 @@ class zendserver::repo::debian {
 
   case $::operatingsystem {
     'Ubuntu' : {
-      if $::lsbdistrelease >= 14.04 {
+      if $::lsbdistrelease + 0 >= 14.04 {
         $zend_repository = "http://repos.zend.com/zend-server/${zendserver::zend_server_version}/deb_apache2.4"
       } else {
         $zend_repository = "http://repos.zend.com/zend-server/${zendserver::zend_server_version}/deb_ssl1.0"


### PR DESCRIPTION
Puppet 4 is more strict about comparisons between different types. Because facter returns `lsbdistrelease` as a string with a number in it, in order to compare it to a number we have to convert it to a number by adding 0 to it (https://docs.puppet.com/puppet/latest/reference/lang_data_number.html#converting-strings-to-numbers).