### PR TITLE
Misleading commented params

### DIFF
--- a/manifests/application/define.pp
+++ b/manifests/application/define.pp
@@ -15,8 +15,6 @@
 # It is advised you add a puppet "File" resource for the logo file and "require" it. 
 # [*user_app_name*]
 # The user application's name (alias) (Default: resource name)
-# [*create_vhost*]
-# Whether to create a web server vhost to access the app.
 # [*user_params*]
 # Optional parameters to pass to the deployment command.
 


### PR DESCRIPTION
I think that these 2 lines should not be there: https://github.com/zend-patterns/ZendServerPuppet/blob/master/manifests/application/define.pp#L18-L19

AFAIK, create_vhost only applies to applicationDeploy and installApp