### PR TITLE
Update application.pp

### DIFF
--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -49,7 +49,6 @@ define zendserver::application (
   $cwd           = undef,
 ) {
 
-  notify {"target: ${target}":}
   case $ensure {
     'present', 'deployed'  : {
       zendserver::application::deploy { $name:


### PR DESCRIPTION
Notifies is not unique unless target is unique. When many apps are defined for a client, puppet tries to output the same notify twice, which is a duplicate declaration, according to puppet.

`Error: Duplicate declaration: Notify[target: localadmin] is already declared in file /etc/puppet/modules/zendserver/manifests/application.pp:52; cannot redeclare at /etc/puppet/modules/zendserver/manifests/application.pp:52 on node`