### PR TITLE
Added vhost and directives support

### DIFF
--- a/facts.d/get_vhost_details.php
+++ b/facts.d/get_vhost_details.php
@@ -1,0 +1,26 @@
+#!/usr/local/zend/bin/php
+<?php
+error_reporting(E_ERROR);
+
+$zs_api_config_file='/.zsapi.ini';
+$zs_api_target='localadmin';
+$zs_api_config=parse_ini_file($zs_api_config_file, true);
+
+$api_key_name=$zs_api_config[$zs_api_target]['zskey'];
+$api_key_hash=$zs_api_config[$zs_api_target]['zssecret'];
+
+$get_vhost_details="/usr/local/zend/bin/zs-manage vhost-get-status -N $api_key_name -K $api_key_hash 2>/dev/null|cut -f 2,3,4,5,6,7";
+
+exec($get_vhost_details , $vhost_exec_output);
+#print_r ($vhost_exec_output);
+foreach ($vhost_exec_output as $line){
+  if (preg_match("/\[NOTICE\]/",$line)) {
+  } else {
+    $vhost_properties=explode("\t",$line);
+    echo "zend_vhost_id_$vhost_properties[1]_$vhost_properties[2]=$vhost_properties[0]".PHP_EOL;
+    echo "zend_vhost_name_$vhost_properties[1]_$vhost_properties[2]=$vhost_properties[1]".PHP_EOL;
+    echo "zend_vhost_port_$vhost_properties[1]_$vhost_properties[2]=$vhost_properties[2]".PHP_EOL;
+    echo "zend_vhost_deploy_$vhost_properties[1]_$vhost_properties[2]=$vhost_properties[3]".PHP_EOL;
+    echo "zend_vhost_status_$vhost_properties[1]_$vhost_properties[2]=$vhost_properties[4]".PHP_EOL;
+  }
+}

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -49,12 +49,6 @@ define zendserver::application (
   $cwd           = undef,
 ) {
 
-  # Notifies if the bootstrap is not complete
-
-  if str2bool($::zend_gui_completed) != true {
-    notify {"You will see error messages if the application settings are applied before the bootstrap is complete. If it's the case, just run puppet again.": }
-  }
-
   case $ensure {
     'present', 'deployed'  : {
       zendserver::application::deploy { $name:

--- a/manifests/application.pp
+++ b/manifests/application.pp
@@ -49,6 +49,12 @@ define zendserver::application (
   $cwd           = undef,
 ) {
 
+  # Notifies if the bootstrap is not complete
+
+  if str2bool($::zend_gui_completed) != true {
+    notify {"You will see error messages if the application settings are applied before the bootstrap is complete. If it's the case, just run puppet again.": }
+  }
+
   case $ensure {
     'present', 'deployed'  : {
       zendserver::application::deploy { $name:

--- a/manifests/bootstrap.pp
+++ b/manifests/bootstrap.pp
@@ -13,6 +13,7 @@ class zendserver::bootstrap inherits zendserver {
   }
 
   if $::zend_gui_completed != 'true' {
+    notify {"You may see error messages if vhost, app, etc. settings are applied (defined) before the bootstrap is complete. If it's the case, just run puppet again.": }
     include zendserver::bootstrap::exec
   }
 }

--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -1,0 +1,35 @@
+# == Definition: zendserver::directive
+#   Define a php configuration value (directives)
+# === Parameters
+# [*directive_value*]
+# Desired value for the directive. For example: on or 10M. Required.
+# === Examples
+#
+# Minimalist
+#
+#  zendserver::directive { 'allow_url_include':
+#    directive_value  => 'on',
+#  }
+#
+#  zendserver::directive { 'upload_max_filesize':
+#    directive_value  => '20M',
+#  }
+
+define zendserver::directive (
+  $directive_value,
+  $target                   = 'localadmin',
+) {
+
+  zendserver::sdk::command { "directive_${name}":
+    target             => $target,
+    api_command        => 'configurationStoreDirectives',
+    additional_options => "--directives=\"${name}=${directive_value}\"",
+    onlyif             => "/usr/local/zend/bin/zs-client.sh configurationDirectivesList --target=${target} --filter=${name} | grep fileValue | grep -qiv \'\[CDATA\[${directive_value}\]\]\'",
+  } ->
+  zendserver::sdk::command { "directive_reload_${name}":
+    target      => $target,
+    api_command => 'restartPhp',
+    onlyif      => "/usr/local/zend/bin/zs-client.sh configurationDirectivesList --target=${target} --filter=${name} | grep fileValue | grep -qiv \'\[CDATA\[${directive_value}\]\]\'",
+  }
+
+}

--- a/manifests/directive.pp
+++ b/manifests/directive.pp
@@ -5,15 +5,18 @@
 # Desired value for the directive. For example: on or 10M. Required.
 # === Examples
 #
-# Minimalist
+# Boolean: 0 (off) or 1 (on)
 #
 #  zendserver::directive { 'allow_url_include':
-#    directive_value  => 'on',
+#    directive_value  => '0',
 #  }
 #
 #  zendserver::directive { 'upload_max_filesize':
 #    directive_value  => '20M',
 #  }
+#
+# Todo: paths
+# Todo: other types?
 
 define zendserver::directive (
   $directive_value,

--- a/manifests/sdk/command.pp
+++ b/manifests/sdk/command.pp
@@ -33,6 +33,7 @@ define zendserver::sdk::command (
   $try_sleep          = 5,
   $cwd                = undef,
   $zs_version         = $zendserver::zend_server_version,
+  $onlyif             = [],
 ) {
 
 if versioncmp($zs_version, '8.5') >= 0 {
@@ -51,6 +52,7 @@ if versioncmp($zs_version, '8.5') >= 0 {
       command   => "${zs_client} ${api_command} --target=${target} ${additional_options} ",
       logoutput => true,
       require => File['/usr/local/zend/bin/zs-client.phar'],
+      onlyif => $onlyif,
     }
   } else {
     exec { "zsapi_${name}":

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -1,0 +1,92 @@
+# == Definition: zendserver::vhost
+#   Deploy or define a Zend Server virtual host. 
+# === Parameters
+# [*ensure*]
+# present or absent, required.
+# [*vhostname*]
+# The real name of the vhost.  For example, if you want to have an application at http://myapp.com, the
+# value for vhostname will be myapp.com. Required. We could not simply take the resource name because, 
+# in some cases, one may need to configure a vhost that listens to more than one port, making the
+# resources names non-unique, which puppet refuses. Required.
+# [*target*]
+# Zend Server SDK target to use for the virtual host methods. Defaults to the module's default, localadmin
+# [*port*]
+# Port of virtual host. Defaults to 80 for this module.
+# [*secure*]
+# True if to be served over https. Defaults to false.
+# [*sslCertificatePath*]
+# secure-specific.  File path to locate the SSL certificate file.
+# [*sslCertificateKeyPath*]
+# secure-specific.  File path to locate the SSL private key file.
+# [*sslCertificateChainPath*]
+# secure-specific.  File path to the SSL chain file.
+# [*template*]
+# Template of the virtual host settings according to the web server configuration options.
+# Or an absolute path to a local template vhost file.
+# A local template vhost file is a file that should be present on the machine where zs-client is running.
+# [*force_create*]
+# Force the creation of a virtual host, even if it fails syntax validation. Default: FALSE
+# === Examples
+#
+# Minimalist
+#
+#   zendserver::vhost { 'vhost1':
+#     ensure     => 'present',
+#     vhostname  => 'vhost1',
+#  }
+#
+# Complex - http
+#
+# If you have a vhosts that listens to different
+# ports, make sure you use distinct names like these:
+#
+#   zendserver::vhost { 'vhost1test_90':
+#     ensure     => 'present',
+#     vhostname  => 'vhost1test',
+#     port       => '90',
+#  }
+#
+#   zendserver::vhost { 'vhosttest_89':
+#     ensure     => 'present',
+#     vhostname  => 'vhost1test',
+#     port       => '89',
+#  }
+
+define zendserver::vhost (
+  $ensure,
+  $vhostname,
+  $target                   = 'localadmin',
+  $port                     = 80,
+  $secure                   = false,
+  $sslCertificatePath       = undef,
+  $sslCertificateKeyPath    = undef,
+  $sslCertificateChainPath  = undef,
+  $template                 = undef,
+  $force_create             = false,
+) {
+
+  case $ensure {
+    'present' : {
+      zendserver::vhost::add { $name:
+        target                  => $target,
+        port                    => $port,
+        vhostname               => $vhostname,
+        secure                  => $secure,
+        sslCertificatePath      => $sslCertificatePath,
+        sslCertificateKeyPath   => $sslCertificateKeyPath,
+        sslCertificateChainPath => $sslCertificateChainPath,
+        template                => $template,
+        force_create            => $force_create,
+      }
+    }
+    'absent' : {
+      zendserver::vhost::remove { $name:
+        target        => $target,
+        port          => $port,
+        vhostname     => $vhostname,
+      }
+    }
+    default                : {
+    }
+  }
+}

--- a/manifests/vhost.pp
+++ b/manifests/vhost.pp
@@ -30,10 +30,21 @@
 #
 # Minimalist
 #
-#   zendserver::vhost { 'vhost1':
-#     ensure     => 'present',
-#     vhostname  => 'vhost1',
+#  zendserver::vhost { 'vhost1':
+#    ensure     => 'present',
+#    vhostname  => 'vhost1',
 #  }
+#
+# Delete a vhost
+#
+#  zendserver::vhost { 'vhost1':
+#    ensure     => 'absent',
+#    vhostname  => 'vhost1',
+#  }
+# 
+# Please note that you cannot edit a vhost with this module
+# You must edit it from the Zend Server interface or
+# delete and re-create the vhost using this module
 #
 # Complex - http
 #
@@ -46,10 +57,19 @@
 #     port       => '90',
 #  }
 #
-#   zendserver::vhost { 'vhosttest_89':
-#     ensure     => 'present',
-#     vhostname  => 'vhost1test',
-#     port       => '89',
+#  zendserver::vhost { 'vhosttest_89':
+#    ensure     => 'present',
+#    vhostname  => 'vhost1test',
+#    port       => '89',
+#  }
+# 
+# Using a specific template
+# Note: the template must already exist on the puppet client
+#
+#  zendserver::vhost { 'vhost2':
+#    ensure        => 'present',
+#    vhostname     => 'vhost2',
+#    template      => '/usr/local/zend/share/vhost_puppet_test.tpl',
 #  }
 
 define zendserver::vhost (

--- a/manifests/vhost/add.pp
+++ b/manifests/vhost/add.pp
@@ -1,0 +1,61 @@
+# == Define: zendserver::vhost::add
+# Define an existing application in Zend Server(that was not installed using Zend Server).
+# This definition is for internal use, do not include it directly in your manifest - it is called by zendserver::application. 
+# === Parameters
+# [*target*]
+# Zend Server SDK target to use for the virtual host methods. Defaults to the module's default, localadmin
+# [*port*]
+# Port of virtual host. Default to 80 for this module.
+# [*secure*]
+# True if to be served over https. Defaults to false.
+# [*sslCertificatePath*]
+# secure-specific.  File path to locate the SSL certificate file.
+# [*sslCertificateKeyPath*]
+# secure-specific.  File path to locate the SSL private key file.
+# [*sslCertificateChainPath*]
+# secure-specific.  File path to the SSL chain file.
+# [*template*]
+# Template of the virtual host settings according to the web server configuration options.
+# Or an absolute path to a local template vhost file.
+# A local template vhost file is a file that should be present on the machine where zs-client is running.
+# [*force_create*]
+# Force the creation of a virtual host, even if it fails syntax validation. Default: FALSE
+
+define zendserver::vhost::add (
+  $target,
+  $vhostname               = $vhostname,
+  $port                    = $port,
+  $secure                  = $secure,
+  $sslCertificatePath      = $sslCertificatePath,
+  $sslCertificateKeyPath   = $sslCertificateKeyPath,
+  $sslCertificateChainPath = $sslCertificateChainPath,
+  $template                = $template,
+  $force_create            = $force_create,) {
+  $required_options        = "--name=${vhostname} --port=${port}"
+
+  $additional_options      = $required_options
+  $secure_options          = "--sslCertificatePath=${sslCertificatePath} --sslCertificateKeyPath=${sslCertificateKeyPath}"
+
+# ${name}_${port} is required to make the vhost unique. Many vhosts can have the same name if they run on different ports
+  $vhost_name_fact       = getvar("::zend_vhost_name_${vhostname}_${port}")
+
+#Debug
+#  notify{ "name: ${name}": }
+#  notify{ "port: ${port}": }
+#  notify{ "name_port: ${name}_${port}": }
+#  notify{ "vhostname: ${vhostname}": }
+#  notify{ "secure: ${secure}": }
+#  notify{ "target: ${target}": }
+
+#Check if vhost exists by using facter
+  if $vhost_name_fact != undef {
+
+  } else {
+    zendserver::sdk::command { "vhost_add_${vhostname}_${port}":
+      target             => $target,
+      api_command        => 'vhostAdd',
+      additional_options => $additional_options,
+      notify             => Service['zend-server'],
+    }
+  }
+}

--- a/manifests/vhost/add.pp
+++ b/manifests/vhost/add.pp
@@ -37,8 +37,8 @@ define zendserver::vhost::add (
     default => "--template=${template}"
   }
   $force_create_option     = $force_create ? {
-    ''      => '',
-    default => '--forceCreation=true'
+    'true'      => '--forceCreation=true',
+    default => ''
   }
 
   $additional_options      = "${required_options} ${template_option} ${force_create_option}"

--- a/manifests/vhost/add.pp
+++ b/manifests/vhost/add.pp
@@ -38,7 +38,7 @@ define zendserver::vhost::add (
   }
   $force_create_option     = $force_create ? {
     ''      => '',
-    default => "--forceCreation=true"
+    default => '--forceCreation=true'
   }
 
   $additional_options      = "${required_options} ${template_option} ${force_create_option}"
@@ -55,10 +55,10 @@ define zendserver::vhost::add (
       target             => $target,
       api_command        => 'vhostAdd',
       additional_options => $additional_options,
-    }
+    } ->
     zendserver::sdk::command { "vhost_reload_${vhostname}_${port}":
-      target             => $target,
-      api_command        => 'restartPhp',
+      target      => $target,
+      api_command => 'restartPhp',
     }
   }
 }

--- a/manifests/vhost/remove.pp
+++ b/manifests/vhost/remove.pp
@@ -42,7 +42,12 @@ define zendserver::vhost::remove (
       target             => $target,
       api_command        => 'vhostRemove',
       additional_options => $required_options,
+    } ->
+    zendserver::sdk::command { "vhost_reload_${vhostname}_${port}":
+      target      => $target,
+      api_command => 'restartPhp',
     }
+
   } else {
 
   }

--- a/manifests/vhost/remove.pp
+++ b/manifests/vhost/remove.pp
@@ -1,0 +1,49 @@
+# == Define: zendserver::vhost::remove
+# Remove a Virtual Host using the Zend Server SDK (zs-client).
+# This is an internal definition, it should not be called directly in the manifest.
+# === Parameters
+# [*target]
+# Zend Server SDK target from which to remove the application.
+# [*user_vhost_name*]
+# The user application's name (alias) (Default: definition name)
+
+define zendserver::vhost::remove (
+  $target,
+  $vhostname               = $vhostname,
+  $port                    = $port,
+  $secure                  = $secure,
+  $sslCertificatePath      = $sslCertificatePath,
+  $sslCertificateKeyPath   = $sslCertificateKeyPath,
+  $sslCertificateChainPath = $sslCertificateChainPath,
+  $template                = $template,
+  $force_create            = $force_create,) {
+
+# ${name}_${port} is required to make the vhost unique. Many vhosts can have the same name if they run on different ports
+  $vhost_name_fact       = getvar("::zend_vhost_name_${vhostname}_${port}")
+
+#Debug
+#  notify{ "name: ${name}": }
+#  notify{ "port: ${port}": }
+#  notify{ "vhost_name-fact: ${vhost_name_fact}": }
+#  notify{ "vhostname: ${vhostname}": }
+#  notify{ "secure: ${secure}": }
+#  notify{ "target: ${target}": }
+
+
+
+  # Check if application is deployed by using facter
+  if $vhost_name_fact != undef {
+    # Get application id from facter
+    $vhost_id           = getvar("::zend_vhost_id_${vhostname}_${port}")
+
+    $required_options = "--vhosts==${vhost_id}"
+
+    zendserver::sdk::command { "vhost_remove_${vhostname}_${port}":
+      target             => $target,
+      api_command        => 'vhostRemove',
+      additional_options => $required_options,
+    }
+  } else {
+
+  }
+}


### PR DESCRIPTION
This PR adds the ability to add and remove a vhost.  PHP is `reloaded` via the API after a change so that the change is applied.

It only works with regular (http) vhosts.  It doesn't work for SSL or iSeries vhosts.