### PR TITLE
Added conditional check for manage_repos so that we don't have a depe…

### DIFF
--- a/manifests/install/redhat.pp
+++ b/manifests/install/redhat.pp
@@ -1,6 +1,11 @@
 # == Class: zendserver::install::redhat
 #  RedHat specific settings for Zend Server install
 class zendserver::install::redhat inherits zendserver::install {
-  Package[$zendserver::install::zendserverpkgname] {
-    require => [Yumrepo['Zend'], Yumrepo['Zend_noarch']], }
+
+  # We don't need to set requirements if we aren't managing the repositories.
+  if $zendserver::manage_repos {
+    Package[$zendserver::install::zendserverpkgname] {
+      require => [Yumrepo['Zend'], Yumrepo['Zend_noarch']], }
+  }
+
 }


### PR DESCRIPTION
…ndency when we don't need one.

There's no need to have dependencies on the yum repo if you're not managing the repositories.

This is useful if you have a satellite or spacewalk server and your linux machines are subscribed to the channel that houses the Zend RPMs.