### PR TITLE
"version_requirement" for dependencies

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,11 +3,11 @@
   "dependencies": [
     {
       "name": "puppetlabs/stdlib",
-      "version_requirement": "4.3.2"
+      "version_requirement": ">= 4.3.2"
     },
     {
       "name": "puppetlabs/apt",
-      "version_requirement": "1.6.0"
+      "version_requirement": ">= 1.6.0"
     }
   ],
   "operatingsystem_support": [


### PR DESCRIPTION
I changed the values "version_requirement" for dependencies to values that make more sense.  It was insisting on one version.  Not sure if it would break anything, but it was broken anyway because it forced the user to force to use versions that were current years ago.